### PR TITLE
fix: use dnf instead of yum in Dockerfile — Python 3.13 Lambda base is AL2023

### DIFF
--- a/Dockerfile.download
+++ b/Dockerfile.download
@@ -4,13 +4,14 @@
 FROM public.ecr.aws/lambda/python:3.13
 
 # Install ffmpeg (required by scdl for audio conversion)
-RUN yum install -y tar xz && \
+# Python 3.13 Lambda base uses AL2023 (dnf), not AL2 (yum)
+RUN dnf install -y tar xz && \
     curl -L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -o /tmp/ffmpeg.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz -C /tmp && \
     mv /tmp/ffmpeg-*-amd64-static/ffmpeg /usr/local/bin/ && \
     mv /tmp/ffmpeg-*-amd64-static/ffprobe /usr/local/bin/ && \
     rm -rf /tmp/ffmpeg* && \
-    yum clean all
+    dnf clean all
 
 # Verify ffmpeg installation
 RUN ffmpeg -version


### PR DESCRIPTION
The Python 3.13 AWS Lambda base image uses Amazon Linux 2023 which ships with dnf, not yum. The Docker build fails with `yum: command not found`. Replaced `yum` with `dnf` in Dockerfile.download.